### PR TITLE
求人編集　誤作動修正

### DIFF
--- a/app/views/jobs/show.html.haml
+++ b/app/views/jobs/show.html.haml
@@ -1,6 +1,6 @@
 .wrapper
   = render partial: "layouts/header"
-  - if company_signed_in?
+  - if @job.company_id == current_company.id 
     .new-btn
       = link_to edit_job_path do
         .new-btn__icon


### PR DESCRIPTION
#What
　求人を出した企業のみが、求人を編集できるように修正。

#Why
　掲載した企業以外の企業も編集できてしまっていたため。